### PR TITLE
ロケール由来の検索不能エラーを修正

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.Text.RegularExpressions;
+using System.Globalization;
 
 using System.IO;
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -45,8 +45,8 @@ namespace VRCLogAnalyzer
 
             //デフォルト表示は、直近1週間
             DateTime today = DateTime.Today;
-            StartDate.Text = today.AddDays(-7).ToLongDateString();
-            EndDate.Text = today.ToLongDateString();
+            StartDate.SelectedDate = today.AddDays(-7);
+            EndDate.SelectedDate = today;
 
             setDatabasePath();
             updateView();
@@ -96,8 +96,8 @@ namespace VRCLogAnalyzer
             _dtos = new ObservableCollection<Dto>();
 
             //VRCのログの日付の区切りがドットなので、それに揃える
-            string queryStartDate = StartDate.Text.Replace("/", ".");
-            string queryEndDate = EndDate.Text.Replace("/", ".") + " 23:59:59";
+            string queryStartDate = StartDate.SelectedDate?.ToString("yyyy.MM.dd", CultureInfo.InvariantCulture) ?? "";
+            string queryEndDate = EndDate.SelectedDate?.ToString("yyyy.MM.dd", CultureInfo.InvariantCulture) + " 23:59:59" ?? "";
 
             //LIKE句で部分一致させる
             //LIKE句でエスケープが必要な特殊文字が含まれていたら、「|」でエスケープ処理する

--- a/VRCLogAnalyzer.csproj
+++ b/VRCLogAnalyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/VRCLogAnalyzer.csproj
+++ b/VRCLogAnalyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
システム時刻が2026年以降になると、SQLiteに渡される時間文字列が以下のようになります。
```
queryStartDate = 2026年2月月16日 月曜日
queryEndDate = 2026年2月月23日 月曜日 23:59:59
```
SQLiteに格納されている時間文字列はドット区切りのため、SQLiteからの返答が空になり検索結果が空になる問題が発生しています。

ToLongDateString()はシステムロケールによって出力が変わってしまうため、より明示的なドット区切りの日付文字列を出力するように変更しました。